### PR TITLE
[Add] create DynSerializerMixin

### DIFF
--- a/test_samples/sample/sampleapp/urls.py
+++ b/test_samples/sample/sampleapp/urls.py
@@ -1,12 +1,14 @@
 from django.conf.urls import url, include
-
 from rest_framework.routers import DefaultRouter
+
 from test_samples.sample.sampleapp import views, views_author, views_review
 
 router = DefaultRouter()
 router.register('article', views.ArticleViewSet)
 router.register('article_limit_fields', views.ArticleViewSetLimitFields)
 router.register('author', views_author.AuthorViewSet)
+router.register('dynmixin_article', views_author.ArticleDynMixinViewSet)
+router.register('dynmixin_author', views_author.AuthorDynMixinViewSet)
 router.register('review', views_review.ReviewViewSet)
 
 urlpatterns = [

--- a/test_samples/sample/sampleapp/views_author.py
+++ b/test_samples/sample/sampleapp/views_author.py
@@ -1,7 +1,8 @@
 from rest_framework import viewsets
-
 # Create your views here.
-from rest_framework_dyn_serializer import DynModelSerializer
+from rest_framework.serializers import ModelSerializer
+
+from rest_framework_dyn_serializer import DynModelSerializer, DynSerializerMixin
 from test_samples.sample.sampleapp.models import Article, Author, Review
 
 
@@ -33,6 +34,32 @@ class AuthorDynSerializer(DynModelSerializer):
         limit_fields = True
 
 
+class ArticleDynMixinSerializer(DynSerializerMixin, ModelSerializer):
+    review = ReviewDynSerializer(many=True, source='reviews')
+
+    class Meta:
+        model = Article
+        fields = ['id', 'title', 'created', 'updated', 'content', 'review']
+
+
+class AuthorDynMixinSerializer(DynSerializerMixin, ModelSerializer):
+    article = ArticleDynMixinSerializer(many=True, source='articles')
+
+    class Meta:
+        model = Author
+        fields = ['id', 'name', 'birth_date', 'article']
+
+
 class AuthorViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AuthorDynSerializer
+    queryset = Author.objects.all().order_by('id')
+
+
+class ArticleDynMixinViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = ArticleDynMixinSerializer
+    queryset = Article.objects.all().order_by('id')
+
+
+class AuthorDynMixinViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = AuthorDynMixinSerializer
     queryset = Author.objects.all().order_by('id')


### PR DESCRIPTION
a serializer inherited DynSerializerMixin can have DynModelSerializer fields without fields_param attribute.

ex)

```py
class AuthorDynSerializer(DynModelSerializer):
    article = ArticleDynSerializer(many=True, source='articles')

    class Meta:
        model = Author
        fields_param = 'author_fields'
        fields = ['id', 'name', 'birth_date', 'article']
        limit_fields = True


# the serializer not inherit DynModelSerializer. 
# but it have a DynModelSerializer field.
class ArticleDynMixinSerializer(DynSerializerMixin, ModelSerializer):
    review = ReviewDynSerializer(many=True, source='reviews')

    class Meta:
        model = Article
        fields = ['id', 'title', 'created', 'updated', 'content', 'review']

```
